### PR TITLE
If no models found allow Metalsmith to continue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -7,11 +7,19 @@ module.exports = function(opts) {
 
   return function(files, metalsmith, done) {
     fileCount = 0;
+    var modelCount = 0;
+
     Object.keys(files).forEach(function(file) {
 
       var filePath;
       debug('stringifying file: %s', file);
       var data = files[file];
+
+      for (var key in data) {
+        if (key === 'model') {
+          modelCount++;
+        }
+      }
 
       if (typeof data.model === 'string') {
         filePath = metalsmith.path(dir, data.model) + '.json';
@@ -37,8 +45,11 @@ module.exports = function(opts) {
         });
       }
     });
+    if (modelCount === 0) {
+      done();
+    }
   };
-}
+};
 
 function readFile(path, metalsmith, done, callback) {
   fileCount++;

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
     "metalsmith-in-place": "^1.4.3",
     "metalsmith-layouts": "^1.6.4",
     "metalsmith-markdown": "0.2.1"
+  },
+  "dependencies": {
+    "debug": "^2.5.1"
   }
 }


### PR DESCRIPTION
## The Issue
If no `model` is found in any file front matter the plugin stops Metalsmith from continuing the build.

## The Fix
Keeps track of `model` in files and if none are found allows Metalsmith to continue building.